### PR TITLE
Update purrr module

### DIFF
--- a/purrr_basics/exercises.Rmd
+++ b/purrr_basics/exercises.Rmd
@@ -81,19 +81,7 @@ Pass diabetes to `map()` and map using `class()`. What are these results telling
 
 ```
 
-## Your Turn 5 
-
-Use `group_modify()` and `lm()` to model `chol` (the outcome) with `ratio`, grouped by `location`
-
-```{r YT5}
-diabetes %>% 
-  group_by(__________) %>% 
-  group_modify(~ broom::tidy(lm(____ ~ ______, data = .x)))
-```
-
-
-
-## Your Turn 6
+## Your Turn 5
 
 Write a function that returns the mean and standard deviation of a numeric vector.
 1. Give the function a name
@@ -108,7 +96,7 @@ _______ <- function(x) {
 }
 ```
 
-## Your Turn 7
+## Your Turn 6
 
 Do the same as #4 above but return a vector instead of a list. 
 
@@ -117,7 +105,7 @@ Do the same as #4 above but return a vector instead of a list.
 ```
 
 
-## Your Turn 8
+## Your Turn 7
 
 Check `diabetes` for any missing data. 
 
@@ -131,25 +119,27 @@ Check `diabetes` for any missing data.
 
 ```
 
-## Your Turn 9
+## Your Turn 8
 
-1. Turn `diabetes` into a list split by `location` using the `split()` function. Check its length.
+1. Fill in the model_lm function to model chol (the outcome) with ratio and pass the .data argument to lm()
 
-2. Fill in the `model_lm` function to model `chol` (the outcome) with `ratio` and pass the `.data` argument to `lm()`
+2. Group `diabetes` by `location`
 
-3. map `model_lm` to `diabetes_list` so that it returns a data frame (by row).
+3. Use `group_modify()` with `model_lm`
 
 ```{r YT7-00-model_lm-map}
-diabetes_list <- ____(diabetes, diabetes$location)
-length(_____)
-model_lm <- function(.data) {
+model_lm <- function(.data, ...) {
   mdl <- lm(____, data = ____)
   # get model statistics
   broom::glance(mdl)
 }
+
+diabetes %>% 
+  ________ %>% 
+  ________
 ```
 
-## Your Turn 10
+## Your Turn 9
 
 1. Split the `gapminder` dataset into a list by `country`
 
@@ -166,7 +156,7 @@ preds <- map2(________, ________, ________)
 head(preds)
 ```
 
-## Your turn 11
+## Your turn 10
 
 1. Create a new directory using the fs package. Call it "figures".
 
@@ -196,7 +186,7 @@ ______(_______, ________)
 ```
 
 
-## Your Turn 12: Bonus!
+## Your Turn 11: Bonus!
 
 Finish the exercises early? Try this bonus exercise to work with nested columns
 
@@ -205,6 +195,8 @@ Do the same as #9, but use a nested data frame.
 2. Use `map()` in `dplyr::mutate()` to map `data` to `model_lm`. 
 3. What does `nested_glance` look like?
 4. Unnest the data
+
+When might nesting be useful?
 
 ```{r YT10-00}
 diabetes_nested <- diabetes %>% 

--- a/purrr_basics/exercises.Rmd
+++ b/purrr_basics/exercises.Rmd
@@ -141,7 +141,7 @@ diabetes %>%
 
 ## Your Turn 9
 
-1. Split the `gapminder` dataset into a list by `country`
+1. Split the `gapminder` dataset into a list by `country` using the `split()` function
 
 2. Create a list of models using `map()`. For the first argument, pass `gapminder_countries`. For the second, use the `~.f()` notation to write a model with `lm()`. Use `lifeExp` on the left hand side of the formula and `year` on the second. Pass `.x` to the `data` argument.
 
@@ -155,6 +155,17 @@ preds <- map2(________, ________, ________)
 # Look at the first six elements of the list 
 head(preds)
 ```
+
+By the way, we can also solve this problem with `group_map()` since `lm()` stores the data used in a given regression model:
+
+```{r}
+gapminder %>% 
+  group_by(country) %>% 
+  group_map(~ lm(lifeExp ~ year, data = .x)) %>% 
+  map(predict)
+```
+
+Both solutions are fine in this case, but it's useful to know both strategies more generally!
 
 ## Your turn 10
 

--- a/purrr_basics/purrr_basics.Rmd
+++ b/purrr_basics/purrr_basics.Rmd
@@ -588,78 +588,6 @@ head(
 
 ---
 
-## `group_map()` 
-
-### Apply a function across a grouping variable and return a list of grouped tibbles
-
-```{r slide-50-01, eval=FALSE}
-diabetes %>% 
-  group_by(gender) %>% #<<
-  group_map(~ broom::tidy(lm(weight ~ height, data = .x)))
-```
-
---
-
-.small[
-
-```{r slide-50-02, echo=FALSE, highlight.output=c(1,8)}
-diabetes %>% 
-  group_by(gender) %>% #<<
-  group_map(~ broom::tidy(lm(weight ~ height, data = .x)))
-```
-
-]
-
----
-
-## `group_modify()`
-
-###  Apply a function across grouped tibbles and return grouped tibbles
-
-```{r slide-51-01, eval=FALSE}
-diabetes %>% 
-  group_by(gender) %>% #<<
-  group_modify(~ broom::tidy(lm(weight ~ height, data = .x)))
-```
-
---
-
-```{r slide-51-02, echo=FALSE, highlight.output=c(2)}
-diabetes %>% 
-  group_by(gender) %>% #<<
-  group_modify(~ broom::tidy(lm(weight ~ height, data = .x)))
-```
-
-
-
----
-
-## Your Turn 5 
-
-### Use group_modify() and lm() to model chol (the outcome) with ratio, grouped by location
-
----
-
-## Your Turn 5 
-
-
-```{r YT5-slide-53-code, eval=FALSE}
-diabetes %>% 
-  group_by(location) %>% #<<
-  group_modify(~ broom::tidy(lm(chol ~ ratio, data = .x)))
-```
-
---
-
-```{r YT5-slide-53-output, echo=FALSE, highlight.output=c(2)}
-diabetes %>% 
-  group_by(location) %>% #<<
-  group_modify(~ broom::tidy(lm(chol ~ ratio, data = .x)))
-```
-
-
----
-
 #  Review: writing functions
 
 ```{r slide-54, eval = FALSE}
@@ -748,7 +676,7 @@ class: inverse, center, middle, takeaway
 
 ---
 
-## Your Turn 6
+## Your Turn 5
 
 ### Write a function that returns the mean and standard deviation of a numeric vector.
 ### Give the function a name
@@ -770,7 +698,7 @@ map(measurements, mean_sd)
 ```
 ---
 
-## Your Turn 6
+## Your Turn 7
 
 ```{r YT6-slide-62, echo=FALSE}
 mean_sd <- function(x) {
@@ -853,13 +781,13 @@ map_int(gapminder, ~length(unique(.x)))
 
 ---
 
-## Your Turn 7
+## Your Turn 8
 
 ### Do the same as #4 above but return a vector instead of a list. 
 
 ---
 
-## Your Turn 7
+## Your Turn 8
 
 .small[
 
@@ -871,7 +799,7 @@ map_chr(diabetes, class)
 
 ---
 
-## Your Turn 8
+## Your Turn 9
 
 ### Check `diabetes` for any missing data. 
 
@@ -881,7 +809,7 @@ map_chr(diabetes, class)
 
 ---
 
-## Your Turn 8
+## Your Turn 9
 
 .small[
 
@@ -893,7 +821,7 @@ map_lgl(diabetes, ~any(is.na(.x)))
 
 ---
 
-## Your Turn 8
+## Your Turn 9
 
 .small[
 
@@ -904,44 +832,88 @@ map_int(diabetes, ~sum(is.na(.x)))
 
 ---
 
-## Your Turn 9
+## `group_map()` 
 
-### Turn diabetes into a list split by location using the split() function. Check its length.
-### Fill in the model_lm function to model chol (the outcome) with ratio and pass the .data argument to lm()
-### map model_lm to diabetes_list so that it returns a data frame (by row).
+### Apply a function across a grouping variable and return a list of grouped tibbles
+
+```{r slide-50-01, eval=FALSE}
+diabetes %>% 
+  group_by(gender) %>%
+  group_map(~ broom::tidy(lm(weight ~ height, data = .x))) #<<
+```
+
+--
+
+.small[
+
+```{r slide-50-02, echo=FALSE, highlight.output=c(1,8)}
+diabetes %>% 
+  group_by(gender) %>% #<<
+  group_map(~ broom::tidy(lm(weight ~ height, data = .x)))
+```
+
+]
 
 ---
 
-## Your Turn 9
+## `group_modify()`
+
+###  Apply a function across grouped tibbles and return grouped tibbles
+
+```{r slide-51-01, eval=FALSE}
+diabetes %>% 
+  group_by(gender) %>% #<<
+  group_modify(~ broom::tidy(lm(weight ~ height, data = .x)))
+```
+
+--
+
+```{r slide-51-02, echo=FALSE, highlight.output=c(2)}
+diabetes %>% 
+  group_by(gender) %>% #<<
+  group_modify(~ broom::tidy(lm(weight ~ height, data = .x)))
+```
+
+---
+
+## Your Turn 10
+
+### Fill in the model_lm function to model chol (the outcome) with ratio and pass the .data argument to lm()
+### Group `diabetes` by `location`
+### Use `group_modify()` with `model_lm`
+
+---
+
+## Your Turn 10
 
 ```{r YT9-slide-78, eval=FALSE}
-diabetes_list <- split(diabetes, diabetes$location) #<<
-length(diabetes_list)
-model_lm <- function(.data) {
+model_lm <- function(.data, ...) {
   mdl <- lm(chol ~ ratio, data = .data) #<<
   # get model statistics
   broom::glance(mdl)
 }
 
-map(diabetes_list, model_lm) #<<
+diabetes %>% 
+  group_by(location) %>% #<<
+  group_modify(model_lm) #<<
 ```
 
 ---
 
-## Your Turn 9
+## Your Turn 10
 
 .small[
 
 ```{r YT9-slide-79, echo=FALSE}
-diabetes_list <- split(diabetes, diabetes$location)
-length(diabetes_list)
-model_lm <- function(.data) {
+model_lm <- function(.data, ...) {
   mdl <- lm(chol ~ ratio, data = .data)
   # get model statistics
   broom::glance(mdl)
 }
 
-map(diabetes_list, model_lm)
+diabetes %>% 
+  group_by(location) %>% 
+  group_modify(model_lm) 
 ```
 
 ]

--- a/purrr_basics/purrr_basics.Rmd
+++ b/purrr_basics/purrr_basics.Rmd
@@ -988,7 +988,7 @@ map2_dbl(means, sds, rnorm, n = 1)
 
 ## Your Turn 9
 
-### Split the gapminder dataset into a list by country
+### Split the gapminder dataset into a list by country using the `split()` function
 
 ### Create a list of models using map(). For the first argument, pass gapminder_countries. For the second, use the ~.f() notation to write a model with lm(). Use lifeExp on the left hand side of the formula and year on the second. Pass .x to the data argument.
 

--- a/purrr_basics/purrr_basics.Rmd
+++ b/purrr_basics/purrr_basics.Rmd
@@ -308,7 +308,7 @@ gapminder %>%
 
 ---
 
-```{r slide-24-output, echo=FALSE, highlight.output = c(2)}
+```{r slide-25-output, highlight.output = c(2)}
 gapminder %>% 
   group_by(continent) %>% 
   summarise(across(c("lifeExp", "gdpPercap"), list(med = median, 
@@ -685,7 +685,7 @@ class: inverse, center, middle, takeaway
 
 ---
 
-## Your Turn 6
+## Your Turn 5
 
 ```{r YT6-slide-61, eval=FALSE}
 mean_sd <- function(x) {
@@ -698,7 +698,7 @@ map(measurements, mean_sd)
 ```
 ---
 
-## Your Turn 7
+## Your Turn 5
 
 ```{r YT6-slide-62, echo=FALSE}
 mean_sd <- function(x) {
@@ -781,13 +781,13 @@ map_int(gapminder, ~length(unique(.x)))
 
 ---
 
-## Your Turn 8
+## Your Turn 6
 
 ### Do the same as #4 above but return a vector instead of a list. 
 
 ---
 
-## Your Turn 8
+## Your Turn 6
 
 .small[
 
@@ -799,7 +799,7 @@ map_chr(diabetes, class)
 
 ---
 
-## Your Turn 9
+## Your Turn 7
 
 ### Check `diabetes` for any missing data. 
 
@@ -809,7 +809,7 @@ map_chr(diabetes, class)
 
 ---
 
-## Your Turn 9
+## Your Turn 7
 
 .small[
 
@@ -821,7 +821,7 @@ map_lgl(diabetes, ~any(is.na(.x)))
 
 ---
 
-## Your Turn 9
+## Your Turn 7
 
 .small[
 
@@ -842,17 +842,15 @@ diabetes %>%
   group_map(~ broom::tidy(lm(weight ~ height, data = .x))) #<<
 ```
 
---
+---
 
-.small[
+## `group_map()` 
 
-```{r slide-50-02, echo=FALSE, highlight.output=c(1,8)}
+```{r slide-50-02, echo=TRUE, highlight.output=c(1,8)}
 diabetes %>% 
   group_by(gender) %>% #<<
   group_map(~ broom::tidy(lm(weight ~ height, data = .x)))
 ```
-
-]
 
 ---
 
@@ -876,7 +874,7 @@ diabetes %>%
 
 ---
 
-## Your Turn 10
+## Your Turn 8
 
 ### Fill in the model_lm function to model chol (the outcome) with ratio and pass the .data argument to lm()
 ### Group `diabetes` by `location`
@@ -884,7 +882,7 @@ diabetes %>%
 
 ---
 
-## Your Turn 10
+## Your Turn 8
 
 ```{r YT9-slide-78, eval=FALSE}
 model_lm <- function(.data, ...) {
@@ -900,7 +898,7 @@ diabetes %>%
 
 ---
 
-## Your Turn 10
+## Your Turn 8
 
 .small[
 
@@ -988,7 +986,7 @@ map2_dbl(means, sds, rnorm, n = 1)
 
 ---
 
-## Your Turn 10
+## Your Turn 9
 
 ### Split the gapminder dataset into a list by country
 
@@ -998,7 +996,7 @@ map2_dbl(means, sds, rnorm, n = 1)
 
 ---
 
-## Your Turn 10
+## Your Turn 9
 
 ```{r YT10-slide-88,eval=FALSE}
 gapminder_countries <- split(gapminder, gapminder$country) #<<
@@ -1009,7 +1007,7 @@ head(preds, 3)
 
 ---
 
-## Your Turn 10
+## Your Turn 9
 
 ```{r YT10-slide-89,eval=FALSE}
 gapminder_countries <- split(gapminder, gapminder$country)
@@ -1020,7 +1018,7 @@ head(preds, 3)
 
 ---
 
-## Your Turn 10
+## Your Turn 9
 
 ```{r YT10-slide-90, eval=FALSE}
 gapminder_countries <- split(gapminder, gapminder$country)
@@ -1031,7 +1029,7 @@ head(preds, 3)
 
 ---
 
-## Your Turn 10
+## Your Turn 9
 
 ```{r YT10-slide-91, echo = FALSE}
 gapminder_countries <- split(gapminder, gapminder$country)
@@ -1144,7 +1142,7 @@ unlink(temp, recursive = TRUE, force = TRUE)
 
 ---
 
-## Your turn 11
+## Your turn 10
 
 #### Create a new directory using the fs package. Call it "figures".
 
@@ -1156,7 +1154,7 @@ unlink(temp, recursive = TRUE, force = TRUE)
 
 ---
 
-## Your turn 11
+## Your turn 10
 
 ```{r YT11-slide-100, eval = FALSE}
 fs::dir_create("figures")
@@ -1184,7 +1182,7 @@ ggsave_gapminder <- function(variable) {
 
 ---
 
-## Your turn 11
+## Your turn 10
 
 ```{r YT11-slide-101, eval = FALSE}
 vars <- c("lifeExp", "pop", "gdpPercap")

--- a/purrr_basics/purrr_basics.Rmd
+++ b/purrr_basics/purrr_basics.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Functional programming and iteration in R"
+title: "Functional programming in R"
 subtitle: 
 date: "`r Sys.Date()`"
 output:
@@ -299,70 +299,20 @@ select(diabetes, matches("\\d"))
 
 ---
 
-## `mutate(across())` & `summarise()`
-
-### Perform group-wise summaries with `mutate(across())`, `group_by()` and `summarise()`
-
-```{r slide-22-mutate-across-summarise-concept-map, eval=FALSE}
-<DATA> %>% 
-  group_by(<GROUPING VAR>) #<<
-  summarise(across(c(<VARIABLES>), list(<NAMES> = <FUNCTIONS>))) 
-```
-
----
-
-## `mutate(across())` & `summarise()`
-
-### Combine with `tidyselect()` helpers
-
-```{r slide-23-mutate-across-tidyselect-summarise-concept-map, eval=FALSE}
-<DATA> %>% 
-  group_by(<GROUPING VAR>) 
-  summarise(across(contains(<VARIABLES>), list(<NAMES> = #<<
-      <FUNCTIONS>))) 
-```
-
----
-
-## `mutate(across())` & `summarise()`
-
-```{r slide-24-code, eval=FALSE}
+```{r slide-24-code, eval=FALSE, highlight.output = c(2)}
 gapminder %>% 
-  group_by(continent) %>% 
-  summarise(across(c("lifeExp", "gdpPercap"), list(med = median, #<<
+  group_by(continent) %>% #<<
+  summarise(across(c("lifeExp", "gdpPercap"), list(med = median,  #<<
       iqr = IQR))) #<<
 ```
 
---
+---
 
 ```{r slide-24-output, echo=FALSE, highlight.output = c(2)}
 gapminder %>% 
   group_by(continent) %>% 
   summarise(across(c("lifeExp", "gdpPercap"), list(med = median, 
       iqr = IQR)))
-```
-
----
-
-## `mutate(across())` & `summarise()`
-
-
-### New column names are created with `_[function name]`
-
-```{r slide-25-code, eval=FALSE, highlight.output = c(2)}
-gapminder %>% 
-  group_by(continent) %>% 
-  summarise(across(c("lifeExp", "gdpPercap"), list(med = median, #<<
-      iqr = IQR))) #<<
-```
-
---
-
-```{r slide-25-output, echo=FALSE, highlight.output = c(2)}
-gapminder %>% 
-  group_by(continent) %>% 
-  summarise(across(c("lifeExp", "gdpPercap"), list(med = median, #<<
-      iqr = IQR))) #<<
 ```
 
 ---
@@ -385,36 +335,6 @@ gapminder %>%
   group_by(continent) %>% 
   summarise(across(c("lifeExp", "gdpPercap"), list(med = median, #<<
            iqr = IQR), .names = "{.fn}_{.col}")) #<<
-```
-
----
-
-## `mutate(across())` & `summarise()`
-
-### `tidyselect()` helpers and named columns
-
-```{r slide-27-mutate-across-summarise-code, eval=FALSE}
-diabetes %>% 
-  group_by(gender) %>% 
-  summarise(across(starts_with("bp"), mean)) #<<
-```
-
---
-
-```{r slide-27-mutate-across-summarise-code-02, eval=FALSE}
-diabetes %>% 
-  group_by(gender) %>% 
-  summarise(across(starts_with("bp"), list(mean = mean), #<<
-      na.rm = TRUE, .names = "{.fn}_{.col}")) #<<
-```
-
---
-
-```{r slide-27-mutate-across-summarise-highlight, echo=FALSE, highlight.output=c(2)}
-diabetes %>% 
-  group_by(gender) %>% 
-  summarise(across(starts_with("bp"), list(mean = mean), 
-      na.rm = TRUE, .names = "{.fn}_{.col}"))
 ```
 
 ---

--- a/purrr_basics/purrr_basics.html
+++ b/purrr_basics/purrr_basics.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html lang="" xml:lang="">
   <head>
-    <title>Functional programming and iteration in R</title>
+    <title>Functional programming in R</title>
     <meta charset="utf-8" />
-    <meta name="date" content="2021-08-27" />
+    <meta name="date" content="2021-09-03" />
     <script src="libs/header-attrs/header-attrs.js"></script>
     <link href="libs/remark-css/default.css" rel="stylesheet" />
     <link rel="stylesheet" href="theme.css" type="text/css" />
@@ -12,8 +12,8 @@
     <textarea id="source">
 class: center, middle, inverse, title-slide
 
-# Functional programming and iteration in R
-### 2021-08-27
+# Functional programming in R
+### 2021-09-03
 
 ---
 
@@ -70,7 +70,7 @@ list(char = "hello", num = 1, fun = mean)
 ## $fun
 ## function (x, ...) 
 ## UseMethod("mean")
-## &lt;bytecode: 0x134e302d8&gt;
+## &lt;bytecode: 0x1227e2860&gt;
 ## &lt;environment: namespace:base&gt;
 ```
 
@@ -214,7 +214,7 @@ mean
 ```
 ## function (x, ...) 
 ## UseMethod("mean")
-## &lt;bytecode: 0x134e302d8&gt;
+## &lt;bytecode: 0x1227e2860&gt;
 ## &lt;environment: namespace:base&gt;
 ```
 
@@ -228,7 +228,7 @@ sd
 ## function (x, na.rm = FALSE) 
 ## sqrt(var(if (is.vector(x) || is.factor(x)) x else as.double(x), 
 ##     na.rm = na.rm))
-## &lt;bytecode: 0x1218a76d0&gt;
+## &lt;bytecode: 0x125589e08&gt;
 ## &lt;environment: namespace:stats&gt;
 ```
 
@@ -252,7 +252,7 @@ f
 ```
 ## function (x, ...) 
 ## UseMethod("mean")
-## &lt;bytecode: 0x134e302d8&gt;
+## &lt;bytecode: 0x1227e2860&gt;
 ## &lt;environment: namespace:base&gt;
 ```
 
@@ -463,73 +463,15 @@ select(diabetes, matches("\\d"))
 
 ---
 
-## `mutate(across())` &amp; `summarise()`
-
-### Perform group-wise summaries with `mutate(across())`, `group_by()` and `summarise()`
-
-
-```r
-&lt;DATA&gt; %&gt;% 
-* group_by(&lt;GROUPING VAR&gt;)
-  summarise(across(c(&lt;VARIABLES&gt;), list(&lt;NAMES&gt; = &lt;FUNCTIONS&gt;))) 
-```
-
----
-
-## `mutate(across())` &amp; `summarise()`
-
-### Combine with `tidyselect()` helpers
-
-
-```r
-&lt;DATA&gt; %&gt;% 
-  group_by(&lt;GROUPING VAR&gt;) 
-* summarise(across(contains(&lt;VARIABLES&gt;), list(&lt;NAMES&gt; =
-      &lt;FUNCTIONS&gt;))) 
-```
-
----
-
-## `mutate(across())` &amp; `summarise()`
-
 
 ```r
 gapminder %&gt;% 
-  group_by(continent) %&gt;% 
+* group_by(continent) %&gt;%
 * summarise(across(c("lifeExp", "gdpPercap"), list(med = median,
 *     iqr = IQR)))
 ```
 
---
-
-
-```
-## # A tibble: 5 × 5
-*##   continent lifeExp_med lifeExp_iqr gdpPercap_med gdpPercap_iqr
-##   &lt;fct&gt;           &lt;dbl&gt;       &lt;dbl&gt;         &lt;dbl&gt;         &lt;dbl&gt;
-## 1 Africa           47.8       12.0          1192.         1616.
-## 2 Americas         67.0       13.3          5466.         4402.
-## 3 Asia             61.8       18.1          2647.         7492.
-## 4 Europe           72.2        5.88        12082.        13248.
-## 5 Oceania          73.7        6.35        17983.         8072.
-```
-
 ---
-
-## `mutate(across())` &amp; `summarise()`
-
-
-### New column names are created with `_[function name]`
-
-
-```r
-gapminder %&gt;% 
-  group_by(continent) %&gt;% 
-* summarise(across(c("lifeExp", "gdpPercap"), list(med = median,
-*     iqr = IQR)))
-```
-
---
 
 
 ```
@@ -569,40 +511,6 @@ gapminder %&gt;%
 ## 3 Asia             61.8       18.1          2647.         7492.
 ## 4 Europe           72.2        5.88        12082.        13248.
 ## 5 Oceania          73.7        6.35        17983.         8072.
-```
-
----
-
-## `mutate(across())` &amp; `summarise()`
-
-### `tidyselect()` helpers and named columns
-
-
-```r
-diabetes %&gt;% 
-  group_by(gender) %&gt;% 
-* summarise(across(starts_with("bp"), mean))
-```
-
---
-
-
-```r
-diabetes %&gt;% 
-  group_by(gender) %&gt;% 
-* summarise(across(starts_with("bp"), list(mean = mean),
-*     na.rm = TRUE, .names = "{.fn}_{.col}"))
-```
-
---
-
-
-```
-## # A tibble: 2 × 5
-*##   gender mean_bp.1s mean_bp.1d mean_bp.2s mean_bp.2d
-##   &lt;chr&gt;       &lt;dbl&gt;      &lt;dbl&gt;      &lt;dbl&gt;      &lt;dbl&gt;
-## 1 female       136.       82.5       153.       91.8
-## 2 male         138.       84.5       151.       93.5
 ```
 
 ---
@@ -1816,7 +1724,10 @@ class: inverse, center
 <script>var slideshow = remark.create({
 "highlightStyle": "github",
 "highlightLines": true,
-"countIncrementalSlides": false
+"countIncrementalSlides": false,
+"navigation": {
+"scroll": false
+}
 });
 if (window.HTMLWidgets) slideshow.on('afterShowSlide', function (slide) {
   window.dispatchEvent(new Event('resize'));

--- a/purrr_basics/purrr_basics.html
+++ b/purrr_basics/purrr_basics.html
@@ -70,7 +70,7 @@ list(char = "hello", num = 1, fun = mean)
 ## $fun
 ## function (x, ...) 
 ## UseMethod("mean")
-## &lt;bytecode: 0x1162cf860&gt;
+## &lt;bytecode: 0x156cbee60&gt;
 ## &lt;environment: namespace:base&gt;
 ```
 
@@ -214,7 +214,7 @@ mean
 ```
 ## function (x, ...) 
 ## UseMethod("mean")
-## &lt;bytecode: 0x1162cf860&gt;
+## &lt;bytecode: 0x156cbee60&gt;
 ## &lt;environment: namespace:base&gt;
 ```
 
@@ -228,7 +228,7 @@ sd
 ## function (x, na.rm = FALSE) 
 ## sqrt(var(if (is.vector(x) || is.factor(x)) x else as.double(x), 
 ##     na.rm = na.rm))
-## &lt;bytecode: 0x11139cc60&gt;
+## &lt;bytecode: 0x1336932e0&gt;
 ## &lt;environment: namespace:stats&gt;
 ```
 
@@ -252,7 +252,7 @@ f
 ```
 ## function (x, ...) 
 ## UseMethod("mean")
-## &lt;bytecode: 0x1162cf860&gt;
+## &lt;bytecode: 0x156cbee60&gt;
 ## &lt;environment: namespace:base&gt;
 ```
 
@@ -473,6 +473,13 @@ gapminder %&gt;%
 
 ---
 
+
+```r
+gapminder %&gt;% 
+  group_by(continent) %&gt;% 
+  summarise(across(c("lifeExp", "gdpPercap"), list(med = median, 
+      iqr = IQR)))
+```
 
 ```
 ## # A tibble: 5 × 5
@@ -941,7 +948,7 @@ class: inverse, center, middle, takeaway
 
 ---
 
-## Your Turn 6
+## Your Turn 5
 
 
 ```r
@@ -955,7 +962,7 @@ map(measurements, mean_sd)
 ```
 ---
 
-## Your Turn 7
+## Your Turn 5
 
 
 ```
@@ -1072,13 +1079,13 @@ map_int(gapminder, ~length(unique(.x)))
 
 ---
 
-## Your Turn 8
+## Your Turn 6
 
 ### Do the same as #4 above but return a vector instead of a list. 
 
 ---
 
-## Your Turn 8
+## Your Turn 6
 
 .small[
 
@@ -1102,7 +1109,7 @@ map_chr(diabetes, class)
 
 ---
 
-## Your Turn 9
+## Your Turn 7
 
 ### Check `diabetes` for any missing data. 
 
@@ -1112,7 +1119,7 @@ map_chr(diabetes, class)
 
 ---
 
-## Your Turn 9
+## Your Turn 7
 
 .small[
 
@@ -1134,7 +1141,7 @@ map_lgl(diabetes, ~any(is.na(.x)))
 
 ---
 
-## Your Turn 9
+## Your Turn 7
 
 .small[
 
@@ -1166,10 +1173,16 @@ diabetes %&gt;%
 * group_map(~ broom::tidy(lm(weight ~ height, data = .x)))
 ```
 
---
+---
 
-.small[
+## `group_map()` 
 
+
+```r
+diabetes %&gt;% 
+* group_by(gender) %&gt;%
+  group_map(~ broom::tidy(lm(weight ~ height, data = .x)))
+```
 
 ```
 *## [[1]]
@@ -1186,8 +1199,6 @@ diabetes %&gt;%
 ## 1 (Intercept)   -49.7     68.9      -0.722 0.471   
 ## 2 height          3.35     0.995     3.37  0.000945
 ```
-
-]
 
 ---
 
@@ -1218,7 +1229,7 @@ diabetes %&gt;%
 
 ---
 
-## Your Turn 10
+## Your Turn 8
 
 ### Fill in the model_lm function to model chol (the outcome) with ratio and pass the .data argument to lm()
 ### Group `diabetes` by `location`
@@ -1226,7 +1237,7 @@ diabetes %&gt;%
 
 ---
 
-## Your Turn 10
+## Your Turn 8
 
 
 ```r
@@ -1243,7 +1254,7 @@ diabetes %&gt;%
 
 ---
 
-## Your Turn 10
+## Your Turn 8
 
 .small[
 
@@ -1332,7 +1343,7 @@ map2_dbl(means, sds, rnorm, n = 1)
 
 ---
 
-## Your Turn 10
+## Your Turn 9
 
 ### Split the gapminder dataset into a list by country
 
@@ -1342,7 +1353,7 @@ map2_dbl(means, sds, rnorm, n = 1)
 
 ---
 
-## Your Turn 10
+## Your Turn 9
 
 
 ```r
@@ -1354,7 +1365,7 @@ head(preds, 3)
 
 ---
 
-## Your Turn 10
+## Your Turn 9
 
 
 ```r
@@ -1366,7 +1377,7 @@ head(preds, 3)
 
 ---
 
-## Your Turn 10
+## Your Turn 9
 
 
 ```r
@@ -1378,7 +1389,7 @@ head(preds, 3)
 
 ---
 
-## Your Turn 10
+## Your Turn 9
 
 
 ```
@@ -1493,7 +1504,7 @@ gapminder %&gt;%
 
 ---
 
-## Your turn 11
+## Your turn 10
 
 #### Create a new directory using the fs package. Call it "figures".
 
@@ -1505,7 +1516,7 @@ gapminder %&gt;%
 
 ---
 
-## Your turn 11
+## Your turn 10
 
 
 ```r
@@ -1534,7 +1545,7 @@ ggsave_gapminder &lt;- function(variable) {
 
 ---
 
-## Your turn 11
+## Your turn 10
 
 
 ```r

--- a/purrr_basics/purrr_basics.html
+++ b/purrr_basics/purrr_basics.html
@@ -70,7 +70,7 @@ list(char = "hello", num = 1, fun = mean)
 ## $fun
 ## function (x, ...) 
 ## UseMethod("mean")
-## &lt;bytecode: 0x1227e2860&gt;
+## &lt;bytecode: 0x1162cf860&gt;
 ## &lt;environment: namespace:base&gt;
 ```
 
@@ -214,7 +214,7 @@ mean
 ```
 ## function (x, ...) 
 ## UseMethod("mean")
-## &lt;bytecode: 0x1227e2860&gt;
+## &lt;bytecode: 0x1162cf860&gt;
 ## &lt;environment: namespace:base&gt;
 ```
 
@@ -228,7 +228,7 @@ sd
 ## function (x, na.rm = FALSE) 
 ## sqrt(var(if (is.vector(x) || is.factor(x)) x else as.double(x), 
 ##     na.rm = na.rm))
-## &lt;bytecode: 0x125589e08&gt;
+## &lt;bytecode: 0x11139cc60&gt;
 ## &lt;environment: namespace:stats&gt;
 ```
 
@@ -252,7 +252,7 @@ f
 ```
 ## function (x, ...) 
 ## UseMethod("mean")
-## &lt;bytecode: 0x1227e2860&gt;
+## &lt;bytecode: 0x1162cf860&gt;
 ## &lt;environment: namespace:base&gt;
 ```
 
@@ -839,104 +839,6 @@ head(
 
 ---
 
-## `group_map()` 
-
-### Apply a function across a grouping variable and return a list of grouped tibbles
-
-
-```r
-diabetes %&gt;% 
-* group_by(gender) %&gt;%
-  group_map(~ broom::tidy(lm(weight ~ height, data = .x)))
-```
-
---
-
-.small[
-
-
-```
-*## [[1]]
-## # A tibble: 2 × 5
-##   term        estimate std.error statistic   p.value
-##   &lt;chr&gt;          &lt;dbl&gt;     &lt;dbl&gt;     &lt;dbl&gt;     &lt;dbl&gt;
-## 1 (Intercept)   -73.8     59.2       -1.25 0.214    
-## 2 height          3.90     0.928      4.20 0.0000383
-## 
-*## [[2]]
-## # A tibble: 2 × 5
-##   term        estimate std.error statistic  p.value
-##   &lt;chr&gt;          &lt;dbl&gt;     &lt;dbl&gt;     &lt;dbl&gt;    &lt;dbl&gt;
-## 1 (Intercept)   -49.7     68.9      -0.722 0.471   
-## 2 height          3.35     0.995     3.37  0.000945
-```
-
-]
-
----
-
-## `group_modify()`
-
-###  Apply a function across grouped tibbles and return grouped tibbles
-
-
-```r
-diabetes %&gt;% 
-* group_by(gender) %&gt;%
-  group_modify(~ broom::tidy(lm(weight ~ height, data = .x)))
-```
-
---
-
-
-```
-## # A tibble: 4 × 6
-*## # Groups:   gender [2]
-##   gender term        estimate std.error statistic   p.value
-##   &lt;chr&gt;  &lt;chr&gt;          &lt;dbl&gt;     &lt;dbl&gt;     &lt;dbl&gt;     &lt;dbl&gt;
-## 1 female (Intercept)   -73.8     59.2      -1.25  0.214    
-## 2 female height          3.90     0.928     4.20  0.0000383
-## 3 male   (Intercept)   -49.7     68.9      -0.722 0.471    
-## 4 male   height          3.35     0.995     3.37  0.000945
-```
-
-
-
----
-
-## Your Turn 5 
-
-### Use group_modify() and lm() to model chol (the outcome) with ratio, grouped by location
-
----
-
-## Your Turn 5 
-
-
-
-```r
-diabetes %&gt;% 
-* group_by(location) %&gt;%
-  group_modify(~ broom::tidy(lm(chol ~ ratio, data = .x)))
-```
-
---
-
-
-```
-## # A tibble: 4 × 6
-*## # Groups:   location [2]
-##   location   term        estimate std.error statistic  p.value
-##   &lt;chr&gt;      &lt;chr&gt;          &lt;dbl&gt;     &lt;dbl&gt;     &lt;dbl&gt;    &lt;dbl&gt;
-## 1 Buckingham (Intercept)    151.       7.17     21.1  2.13e-52
-## 2 Buckingham ratio           11.9      1.45      8.15 4.11e-14
-## 3 Louisa     (Intercept)    153.       8.50     18.0  1.05e-43
-## 4 Louisa     ratio           12.9      1.79      7.19 1.26e-11
-```
-
-
----
-
 #  Review: writing functions
 
 
@@ -1030,7 +932,7 @@ class: inverse, center, middle, takeaway
 
 ---
 
-## Your Turn 6
+## Your Turn 5
 
 ### Write a function that returns the mean and standard deviation of a numeric vector.
 ### Give the function a name
@@ -1053,7 +955,7 @@ map(measurements, mean_sd)
 ```
 ---
 
-## Your Turn 6
+## Your Turn 7
 
 
 ```
@@ -1170,13 +1072,13 @@ map_int(gapminder, ~length(unique(.x)))
 
 ---
 
-## Your Turn 7
+## Your Turn 8
 
 ### Do the same as #4 above but return a vector instead of a list. 
 
 ---
 
-## Your Turn 7
+## Your Turn 8
 
 .small[
 
@@ -1200,7 +1102,7 @@ map_chr(diabetes, class)
 
 ---
 
-## Your Turn 8
+## Your Turn 9
 
 ### Check `diabetes` for any missing data. 
 
@@ -1210,7 +1112,7 @@ map_chr(diabetes, class)
 
 ---
 
-## Your Turn 8
+## Your Turn 9
 
 .small[
 
@@ -1232,7 +1134,7 @@ map_lgl(diabetes, ~any(is.na(.x)))
 
 ---
 
-## Your Turn 8
+## Your Turn 9
 
 .small[
 
@@ -1253,54 +1155,108 @@ map_int(diabetes, ~sum(is.na(.x)))
 
 ---
 
-## Your Turn 9
+## `group_map()` 
 
-### Turn diabetes into a list split by location using the split() function. Check its length.
-### Fill in the model_lm function to model chol (the outcome) with ratio and pass the .data argument to lm()
-### map model_lm to diabetes_list so that it returns a data frame (by row).
-
----
-
-## Your Turn 9
+### Apply a function across a grouping variable and return a list of grouped tibbles
 
 
 ```r
-*diabetes_list &lt;- split(diabetes, diabetes$location)
-length(diabetes_list)
-model_lm &lt;- function(.data) {
-* mdl &lt;- lm(chol ~ ratio, data = .data)
-  # get model statistics
-  broom::glance(mdl)
-}
-
-*map(diabetes_list, model_lm)
+diabetes %&gt;% 
+  group_by(gender) %&gt;%
+* group_map(~ broom::tidy(lm(weight ~ height, data = .x)))
 ```
 
----
-
-## Your Turn 9
+--
 
 .small[
 
 
 ```
-## [1] 2
+*## [[1]]
+## # A tibble: 2 × 5
+##   term        estimate std.error statistic   p.value
+##   &lt;chr&gt;          &lt;dbl&gt;     &lt;dbl&gt;     &lt;dbl&gt;     &lt;dbl&gt;
+## 1 (Intercept)   -73.8     59.2       -1.25 0.214    
+## 2 height          3.90     0.928      4.20 0.0000383
+## 
+*## [[2]]
+## # A tibble: 2 × 5
+##   term        estimate std.error statistic  p.value
+##   &lt;chr&gt;          &lt;dbl&gt;     &lt;dbl&gt;     &lt;dbl&gt;    &lt;dbl&gt;
+## 1 (Intercept)   -49.7     68.9      -0.722 0.471   
+## 2 height          3.35     0.995     3.37  0.000945
 ```
 
+]
+
+---
+
+## `group_modify()`
+
+###  Apply a function across grouped tibbles and return grouped tibbles
+
+
+```r
+diabetes %&gt;% 
+* group_by(gender) %&gt;%
+  group_modify(~ broom::tidy(lm(weight ~ height, data = .x)))
 ```
-## $Buckingham
-## # A tibble: 1 × 12
-##   r.squared adj.r.squared sigma statistic  p.value    df logLik   AIC   BIC
-##       &lt;dbl&gt;         &lt;dbl&gt; &lt;dbl&gt;     &lt;dbl&gt;    &lt;dbl&gt; &lt;dbl&gt;  &lt;dbl&gt; &lt;dbl&gt; &lt;dbl&gt;
-## 1     0.252         0.248  38.8      66.4 4.11e-14     1 -1009. 2025. 2034.
-## # … with 3 more variables: deviance &lt;dbl&gt;, df.residual &lt;int&gt;, nobs &lt;int&gt;
-## 
-## $Louisa
-## # A tibble: 1 × 12
-##   r.squared adj.r.squared sigma statistic  p.value    df logLik   AIC   BIC
-##       &lt;dbl&gt;         &lt;dbl&gt; &lt;dbl&gt;     &lt;dbl&gt;    &lt;dbl&gt; &lt;dbl&gt;  &lt;dbl&gt; &lt;dbl&gt; &lt;dbl&gt;
-## 1     0.204         0.201  39.4      51.7 1.26e-11     1 -1033. 2072. 2082.
-## # … with 3 more variables: deviance &lt;dbl&gt;, df.residual &lt;int&gt;, nobs &lt;int&gt;
+
+--
+
+
+```
+## # A tibble: 4 × 6
+*## # Groups:   gender [2]
+##   gender term        estimate std.error statistic   p.value
+##   &lt;chr&gt;  &lt;chr&gt;          &lt;dbl&gt;     &lt;dbl&gt;     &lt;dbl&gt;     &lt;dbl&gt;
+## 1 female (Intercept)   -73.8     59.2      -1.25  0.214    
+## 2 female height          3.90     0.928     4.20  0.0000383
+## 3 male   (Intercept)   -49.7     68.9      -0.722 0.471    
+## 4 male   height          3.35     0.995     3.37  0.000945
+```
+
+---
+
+## Your Turn 10
+
+### Fill in the model_lm function to model chol (the outcome) with ratio and pass the .data argument to lm()
+### Group `diabetes` by `location`
+### Use `group_modify()` with `model_lm`
+
+---
+
+## Your Turn 10
+
+
+```r
+model_lm &lt;- function(.data, ...) {
+* mdl &lt;- lm(chol ~ ratio, data = .data)
+  # get model statistics
+  broom::glance(mdl)
+}
+
+diabetes %&gt;% 
+* group_by(location) %&gt;%
+* group_modify(model_lm)
+```
+
+---
+
+## Your Turn 10
+
+.small[
+
+
+```
+## # A tibble: 2 × 13
+## # Groups:   location [2]
+##   location   r.squared adj.r.squared sigma statistic  p.value    df logLik   AIC
+##   &lt;chr&gt;          &lt;dbl&gt;         &lt;dbl&gt; &lt;dbl&gt;     &lt;dbl&gt;    &lt;dbl&gt; &lt;dbl&gt;  &lt;dbl&gt; &lt;dbl&gt;
+## 1 Buckingham     0.252         0.248  38.8      66.4 4.11e-14     1 -1009. 2025.
+## 2 Louisa         0.204         0.201  39.4      51.7 1.26e-11     1 -1033. 2072.
+## # … with 4 more variables: BIC &lt;dbl&gt;, deviance &lt;dbl&gt;, df.residual &lt;int&gt;,
+## #   nobs &lt;int&gt;
 ```
 
 ]


### PR DESCRIPTION
This PR:

* Tightens up the `across()` section, as it felt a smidge too long when teaching it live
* moves `group_map()` and `group_modify()` to later in the slides we have lambda notation and output types addressed first
* Combines the `group_modify()` and `split()` exercise and offers a `group_map()`-based solution for what is now YT 9

FYI @mjfrigaard 